### PR TITLE
feature: rspec Tests for Tic Tac Toe

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ I used RSpec to build unit tests for every method in the enumerable module, #eac
 4. You will see a dropdown menu. Click on "**Download ZIP**".
 5. Go to the directory where you downloaded the **ZIP file** and open it. Extract its contents to any directory you want in your system.
 6. If you are not in your system terminal/command prompt already, please open it and go to the directory where you cloned the remote repository or extracted the project files.
-7. While in the root directory, type `bundle install`. This will install Rspec in your system, in case you don't have it installed already. (It also installs Rubocop; however, this gem is necessary to make the project work).
+7. While in the root directory, type `bundle install`. This will install Rspec in your system, in case you don't have it installed already. (It also installs Rubocop; however, this gem is not necessary to make the project work).
 8. Finally, run the tests by typing the command `rspec --format doc` to see test results.
 
 ## Live Example

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 > In this project I used RSpec to create and run unit tests for previously completed projects in Ruby.
 
-In this project I created a test example for my Enumerables Module, which I built in another project (project link is [here](https://github.com/StarSheriff2/Enumerables)). I used RSpec to build the unit tests for every method in the enumerable module, #each, #each_with_index, #select, #all?, #any?, #none?, #count, #map, and #inject.
+In this project I created two test example files for two Ruby projects I had previously created, one for an Enumerables Module project (project link is [here](https://github.com/StarSheriff2/Enumerables)), and one for a Tic Tac Toe game (project link is [here](https://github.com/StarSheriff2/rb-tic-tac-toe)).
+I used RSpec to build unit tests for every method in the enumerable module, #each, #each_with_index, #select, #all?, #any?, #none?, #count, #map, and #inject; and for the game file of the Tic Tac Toe game, game.rb, testing the main gameplay methods.
 
 ![screenshot](./assets/screenshot.png)
 
@@ -22,11 +23,12 @@ In this project I created a test example for my Enumerables Module, which I buil
 4. You will see a dropdown menu. Click on "**Download ZIP**".
 5. Go to the directory where you downloaded the **ZIP file** and open it. Extract its contents to any directory you want in your system.
 6. If you are not in your system terminal/command prompt already, please open it and go to the directory where you cloned the remote repository or extracted the project files.
-7. While in the root directory, run the tests by typing the command `rspec spec/enumerables_spec.rb --format doc` to see test results.
+7. While in the root directory, type `bundle install`. This will install Rspec in your system, in case you don't have it installed already. (It also installs Rubocop; however, this gem is necessary to make the project work).
+8. Finally, run the tests by typing the command `rspec --format doc` to see test results.
 
 ## Live Example
 
-- to run the tests in this live example, type this in the Shell: `rspec spec/enumerables_spec.rb --format doc`
+- to run the tests in this live example, type this in the Shell: `rspec --format doc`
 
 - [Repl.it link](https://repl.it/@StarSheriff2/Using-RSpec-to-Test-Projects).
 

--- a/spec/enumerables_spec.rb
+++ b/spec/enumerables_spec.rb
@@ -23,6 +23,11 @@ describe Enumerable do
         expect(result).to eq([1, 2, 3])
       end
 
+      it 'calls the given block once for each element and does not return a new array' do
+        result = numbers.my_each { |number| number * 2 }
+        expect(result).to_not eq([2, 4, 6])
+      end
+
       it 'calls the given block once for each element, passing that element as a parameter' do
         arr = []
         numbers.my_each { |number| arr << number * 2 }

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -84,5 +84,30 @@ describe Game do
       result = game_turn.turn(2, player)
       expect(result).to eq(error_message)
     end
+
+    context 'when user\'s position input is valid' do
+      let(:player) { instance_double(Player, name: 'Johnny', moves: [1, 4]) }
+
+      before do
+        allow(game_turn).to receive(:win)
+        allow(player).to receive(:symbol)
+      end
+
+      it 'sends symbol' do
+        expect(player).to receive(:symbol)
+        game_turn.turn(3, player)
+      end
+
+      it 'sends moves' do
+        expect(player).to receive(:moves)
+        game_turn.turn(3, player)
+      end
+
+      it 'sends push' do
+        moves = player.moves
+        expect(moves).to receive(:push)
+        game_turn.turn(3, player)
+      end
+    end
   end
 end

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -1,0 +1,38 @@
+require_relative '../lib/tic_tac_toe/game'
+require_relative '../lib/tic_tac_toe/instructions'
+require_relative '../lib/tic_tac_toe/player'
+
+describe
+
+describe Game do
+  describe '#win' do
+    subject(:game_win) { described_class.new }
+
+    context 'when a player has one straight line on the board' do
+
+      it "changes @winner to player's name" do
+        winner_name = 'Charles'
+        moves = [1, 2, 3]
+        game_win.win(moves, winner_name)
+        winner = game_win.winner
+        expect(winner).to eq('Charles')
+      end
+
+      it "changes @winner to player's name if line is in reverse order" do
+        winner_name = 'Charles'
+        moves = [3, 2, 1]
+        game_win.win(moves, winner_name)
+        winner = game_win.winner
+        expect(winner).to eq('Charles')
+      end
+
+      it "it doesn\'t changes @winner variable if there is no straight line" do
+        winner_name = 'Charles'
+        moves = [1, 2, 4]
+        game_win.win(moves, winner_name)
+        winner = game_win.winner
+        expect(winner).to_not eq('Charles')
+      end
+    end
+  end
+end

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -73,36 +73,38 @@ describe Game do
 
   describe '#turn' do
     subject(:game_turn) { described_class.new }
+    let(:player) { instance_double(Player) }
 
-    it 'returns error message if move is not > 0 or < 10' do
-      error_message = "error! Please select any number from 1 to 9\n"
-      player = instance_double(Player)
-      result = game_turn.turn(10, player)
-      expect(result).to eq(error_message)
-    end
+    context 'when user\'s position input is invalid' do
+      it 'returns error message if move is not > 0 or < 10' do
+        error_message = "error! Please select any number from 1 to 9\n"
+        input = 10
+        result = game_turn.turn(input, player)
+        expect(result).to eq(error_message)
+      end
 
-    it 'returns error message if input is not a number' do
-      error_message = "error! Please select any number from 1 to 9\n"
-      input = 'a'.to_i
-      player = instance_double(Player)
-      result = game_turn.turn(input, player)
-      expect(result).to eq(error_message)
-    end
+      it 'returns error message if input is not a number' do
+        error_message = "error! Please select any number from 1 to 9\n"
+        input = 'a'.to_i
+        result = game_turn.turn(input, player)
+        expect(result).to eq(error_message)
+      end
 
-    it 'returns error message if input is a symbol' do
-      error_message = "error! Please select any number from 1 to 9\n"
-      input = '$'.to_i
-      player = instance_double(Player)
-      result = game_turn.turn(input, player)
-      expect(result).to eq(error_message)
-    end
+      it 'returns error message if input is a symbol' do
+        error_message = "error! Please select any number from 1 to 9\n"
+        input = '$'.to_i
+        result = game_turn.turn(input, player)
+        expect(result).to eq(error_message)
+      end
 
-    it 'returns error message if position is marked already on the board' do
-      error_message = "error! That position is already taken\n"
-      game_turn.game = %w[X O X]
-      player = instance_double(Player)
-      result = game_turn.turn(2, player)
-      expect(result).to eq(error_message)
+      it 'returns error message if position is marked already on the board' do
+        error_message = "error! That position is already taken\n"
+        input = 2
+        game_turn.game = %w[X O X]
+        player = instance_double(Player)
+        result = game_turn.turn(input, player)
+        expect(result).to eq(error_message)
+      end
     end
 
     context 'when user\'s position input is valid' do
@@ -139,10 +141,18 @@ describe Game do
   describe '#change_turn' do
     subject(:game_change_turn) { described_class.new }
 
-    it 'changes player_turn to 1 if player_turn has a value of 0' do
+    it 'changes player_turn to 1 if @player_turn has a value of 0' do
+      game_change_turn.player_turn = 0
       game_change_turn.change_turn
       player_turn = game_change_turn.player_turn
       expect(player_turn).to eq(1)
+    end
+
+    it 'doesn\'t return the current value in @player_turn again' do
+      game_change_turn.player_turn = 1
+      game_change_turn.change_turn
+      player_turn = game_change_turn.player_turn
+      expect(player_turn).to_not eq(1)
     end
   end
 end

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -74,14 +74,30 @@ describe Game do
   describe '#turn' do
     subject(:game_turn) { described_class.new }
 
-    it 'returns string if move is not > 9 or is < 0' do
+    it 'returns error message if move is not > 0 or < 10' do
       error_message = "error! Please select any number from 1 to 9\n"
       player = instance_double(Player)
       result = game_turn.turn(10, player)
       expect(result).to eq(error_message)
     end
 
-    it 'returns string if position is marked' do
+    it 'returns error message if input is not a number' do
+      error_message = "error! Please select any number from 1 to 9\n"
+      input = 'a'.to_i
+      player = instance_double(Player)
+      result = game_turn.turn(input, player)
+      expect(result).to eq(error_message)
+    end
+
+    it 'returns error message if input is a symbol' do
+      error_message = "error! Please select any number from 1 to 9\n"
+      input = '$'.to_i
+      player = instance_double(Player)
+      result = game_turn.turn(input, player)
+      expect(result).to eq(error_message)
+    end
+
+    it 'returns error message if position is marked already on the board' do
       error_message = "error! That position is already taken\n"
       game_turn.game = %w[X O X]
       player = instance_double(Player)
@@ -97,10 +113,25 @@ describe Game do
         allow(player).to receive(:symbol)
       end
 
-      it 'returns a string' do
+      it 'returns a string with feedback about the selected position on the board' do
         text = "\nJohnny, you selected position 3. Now your move is displayed on the board.\n"
-        result = game_turn.turn(3, player)
+        input = 3
+        result = game_turn.turn(input, player)
         expect(result).to eq(text)
+      end
+
+      it 'doesn\'t return error message related to invalid number, symbol or character' do
+        error_message = "error! Please select any number from 1 to 9\n"
+        input = 3
+        result = game_turn.turn(input, player)
+        expect(result).to_not eq(error_message)
+      end
+
+      it 'doesn\'t return error message about position already been taken' do
+        error_message = "error! That position is already taken\n"
+        input = 3
+        result = game_turn.turn(input, player)
+        expect(result).to_not eq(error_message)
       end
     end
   end

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -66,4 +66,15 @@ describe Game do
       end
     end
   end
+
+  describe '#turn' do
+    subject(:game_turn) { described_class.new }
+
+    it 'returns string if move is not > 9 or is < 0' do
+      error_message = "error! Please select any number from 1 to 9\n"
+      player = instance_double(Player)
+      result = game_turn.turn(10, player)
+      expect(result).to eq(error_message)
+    end
+  end
 end

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -112,6 +112,12 @@ describe Game do
         expect(moves).to receive(:push)
         game_turn.turn(3, player)
       end
+
+      it 'returns a string' do
+        text = "\nJohnny, you selected position 3. Now your move is displayed on the board.\n"
+        result = game_turn.turn(3, player)
+        expect(result).to eq(text)
+      end
     end
   end
 end

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -6,7 +6,7 @@ describe
 
 describe Game do
   describe '#win' do
-    context 'when a player has one straight line on the board' do
+    context 'when player has one straight line on the board' do
       subject(:game_win) { described_class.new }
 
       it "changes @winner to player's name" do
@@ -24,12 +24,16 @@ describe Game do
         winner = game_win.winner
         expect(winner).to eq('Charles')
       end
+    end
 
-      it "it doesn\'t changes @winner variable if there is no straight line" do
-        winner_name = 'Charles'
+    context 'when player has no straight line on the board' do
+      subject(:game) { described_class.new }
+
+      it "it doesn\'t changes @winner variable" do
+        current_player = 'Charles'
         moves = [1, 2, 4]
-        game_win.win(moves, winner_name)
-        winner = game_win.winner
+        game.win(moves, current_player)
+        winner = game.winner
         expect(winner).to_not eq('Charles')
       end
     end

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -27,11 +27,11 @@ describe Game do
 
     context 'when player has no straight line on the board' do
       subject(:game) { described_class.new }
-      let(:player) { instance_double(Player, name: 'Tony', moves: [1, 2, 3]) }
+      let(:player_x) { instance_double(Player, name: 'Tony', moves: [1, 2, 4, 5]) }
 
-      it "it doesn\'t changes @winner variable" do
-        current_player = player.name
-        moves = player.moves
+      it "it doesn\'t change @winner variable" do
+        current_player = player_x.name
+        moves = player_x.moves
         game.win(moves, current_player)
         winner = game.winner
         expect(winner).to_not eq('Tony')
@@ -40,12 +40,12 @@ describe Game do
 
     context 'when there are no moves left and no straight line on the board' do
       subject(:game_draw) { described_class.new }
-      let(:player) { instance_double(Player, moves: [1, 2, 3]) }
+      let(:player_x) { instance_double(Player, moves: [1, 3, 6, 7, 8]) }
 
       it "changes @winner to \'draw\'" do
-        moves = player.moves
+        moves = player_x.moves
         game_draw.game = %w[X O X O O X X X O]
-        game_draw.win(moves, player)
+        game_draw.win(moves, player_x)
         winner = game_draw.winner
         expect(winner).to eq('draw')
       end

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -2,8 +2,6 @@ require_relative '../lib/tic_tac_toe/game'
 require_relative '../lib/tic_tac_toe/instructions'
 require_relative '../lib/tic_tac_toe/player'
 
-describe
-
 describe Game do
   describe '#win' do
     context 'when player has one straight line on the board' do

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -54,7 +54,7 @@ describe Game do
     context 'when a player has made less than 3 moves' do
       subject(:game_less_moves) { described_class.new }
       let(:player) { instance_double(Player) }
-      let(:winning_combinations) { object_double("Game::WINNING_COMBINATIONS").as_stubbed_const }
+      let(:winning_combinations) { object_double('Game::WINNING_COMBINATIONS').as_stubbed_const }
 
       it 'does not send each' do
         moves = [1, 2]
@@ -83,7 +83,7 @@ describe Game do
 
     it 'returns string if position is marked' do
       error_message = "error! That position is already taken\n"
-      game_turn.game = ['X', 'O', 'X']
+      game_turn.game = %w[X O X]
       player = instance_double(Player)
       result = game_turn.turn(2, player)
       expect(result).to eq(error_message)

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -66,7 +66,7 @@ describe Game do
         moves = player.moves
         game_less_moves.win(moves, player)
         winner = game_less_moves.winner
-        expect(winner).to be(nil)
+        expect(winner).not_to be_truthy
       end
     end
   end

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -104,4 +104,14 @@ describe Game do
       end
     end
   end
+
+  describe '#change_turn' do
+    subject(:game_change_turn) { described_class.new }
+
+    it 'changes player_turn to 1 if player_turn has a value of 0' do
+      game_change_turn.change_turn
+      player_turn = game_change_turn.player_turn
+      expect(player_turn).to eq(1)
+    end
+  end
 end

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -97,22 +97,6 @@ describe Game do
         allow(player).to receive(:symbol)
       end
 
-      it 'sends symbol' do
-        expect(player).to receive(:symbol)
-        game_turn.turn(3, player)
-      end
-
-      it 'sends moves' do
-        expect(player).to receive(:moves)
-        game_turn.turn(3, player)
-      end
-
-      it 'sends push' do
-        moves = player.moves
-        expect(moves).to receive(:push)
-        game_turn.turn(3, player)
-      end
-
       it 'returns a string' do
         text = "\nJohnny, you selected position 3. Now your move is displayed on the board.\n"
         result = game_turn.turn(3, player)

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -76,5 +76,13 @@ describe Game do
       result = game_turn.turn(10, player)
       expect(result).to eq(error_message)
     end
+
+    it 'returns string if position is marked' do
+      error_message = "error! That position is already taken\n"
+      game_turn.game = ['X', 'O', 'X']
+      player = instance_double(Player)
+      result = game_turn.turn(2, player)
+      expect(result).to eq(error_message)
+    end
   end
 end

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -34,16 +34,35 @@ describe Game do
       end
     end
 
-    context 'when there are no more moves and no line on the board' do
+    context 'when there are no moves left and no straight line on the board' do
       subject(:game_draw) { described_class.new }
       let(:player) { instance_double(Player) }
 
       it "changes @winner to \'draw\'" do
         moves = [1, 2, 4]
-        game_draw.game = ['X', 'O', 'X', 'O', 'O', 'X', 'X', 'X', 'O']
+        game_draw.game = %w[X O X O O X X X O]
         game_draw.win(moves, player)
         winner = game_draw.winner
         expect(winner).to eq('draw')
+      end
+    end
+
+    context 'when a player has made less than 3 moves' do
+      subject(:game_less_moves) { described_class.new }
+      let(:player) { instance_double(Player) }
+      let(:winning_combinations) { object_double("Game::WINNING_COMBINATIONS").as_stubbed_const }
+
+      it 'does not send each' do
+        moves = [1, 2]
+        expect(winning_combinations).to_not receive(:each)
+        game_less_moves.win(moves, player)
+      end
+
+      it 'does not change state of winner' do
+        moves = [1, 2]
+        game_less_moves.win(moves, player)
+        winner = game_less_moves.winner
+        expect(winner).to be(nil)
       end
     end
   end

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -6,9 +6,8 @@ describe
 
 describe Game do
   describe '#win' do
-    subject(:game_win) { described_class.new }
-
     context 'when a player has one straight line on the board' do
+      subject(:game_win) { described_class.new }
 
       it "changes @winner to player's name" do
         winner_name = 'Charles'
@@ -32,6 +31,19 @@ describe Game do
         game_win.win(moves, winner_name)
         winner = game_win.winner
         expect(winner).to_not eq('Charles')
+      end
+    end
+
+    context 'when there are no more moves and no line on the board' do
+      subject(:game_draw) { described_class.new }
+      let(:player) { instance_double(Player) }
+
+      it "changes @winner to \'draw\'" do
+        moves = [1, 2, 4]
+        game_draw.game = ['X', 'O', 'X', 'O', 'O', 'X', 'X', 'X', 'O']
+        game_draw.win(moves, player)
+        winner = game_draw.winner
+        expect(winner).to eq('draw')
       end
     end
   end

--- a/spec/tic_tac_toe_spec.rb
+++ b/spec/tic_tac_toe_spec.rb
@@ -6,18 +6,19 @@ describe Game do
   describe '#win' do
     context 'when player has one straight line on the board' do
       subject(:game_win) { described_class.new }
+      let(:player) { instance_double(Player, name: 'Charles', moves: [1, 2, 3]) }
 
       it "changes @winner to player's name" do
-        winner_name = 'Charles'
-        moves = [1, 2, 3]
+        winner_name = player.name
+        moves = player.moves
         game_win.win(moves, winner_name)
         winner = game_win.winner
         expect(winner).to eq('Charles')
       end
 
       it "changes @winner to player's name if line is in reverse order" do
-        winner_name = 'Charles'
-        moves = [3, 2, 1]
+        winner_name = player.name
+        moves = player.moves
         game_win.win(moves, winner_name)
         winner = game_win.winner
         expect(winner).to eq('Charles')
@@ -26,22 +27,23 @@ describe Game do
 
     context 'when player has no straight line on the board' do
       subject(:game) { described_class.new }
+      let(:player) { instance_double(Player, name: 'Tony', moves: [1, 2, 3]) }
 
       it "it doesn\'t changes @winner variable" do
-        current_player = 'Charles'
-        moves = [1, 2, 4]
+        current_player = player.name
+        moves = player.moves
         game.win(moves, current_player)
         winner = game.winner
-        expect(winner).to_not eq('Charles')
+        expect(winner).to_not eq('Tony')
       end
     end
 
     context 'when there are no moves left and no straight line on the board' do
       subject(:game_draw) { described_class.new }
-      let(:player) { instance_double(Player) }
+      let(:player) { instance_double(Player, moves: [1, 2, 3]) }
 
       it "changes @winner to \'draw\'" do
-        moves = [1, 2, 4]
+        moves = player.moves
         game_draw.game = %w[X O X O O X X X O]
         game_draw.win(moves, player)
         winner = game_draw.winner
@@ -51,17 +53,17 @@ describe Game do
 
     context 'when a player has made less than 3 moves' do
       subject(:game_less_moves) { described_class.new }
-      let(:player) { instance_double(Player) }
+      let(:player) { instance_double(Player, moves: [1, 2]) }
       let(:winning_combinations) { object_double('Game::WINNING_COMBINATIONS').as_stubbed_const }
 
       it 'does not send each' do
-        moves = [1, 2]
+        moves = player.moves
         expect(winning_combinations).to_not receive(:each)
         game_less_moves.win(moves, player)
       end
 
       it 'does not change state of winner' do
-        moves = [1, 2]
+        moves = player.moves
         game_less_moves.win(moves, player)
         winner = game_less_moves.winner
         expect(winner).to be(nil)


### PR DESCRIPTION
I'd like to request to merge this feature branch to the development branch. In this feature, I created test examples for the Tic Tac Toe game I built for another project.

The tests are focused on the Game class only, inside the gam.rb file. I tested all the critical methods only, leaving out attribute reading and writing methods for the Player and Game classes.

to run the tests for the Tic Tac Toe game, type `rspec spec/tic_tac_toe_spec.rb --format doc`